### PR TITLE
Check middleware supports python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           poetry install
           poetry run pyright .
-      
+
       - name: Run tests
         run: |
           poetry run pytest -vv

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ aserto = AsertoMiddleware(**aserto_options)
 
 
 @app.route("/api/users/<id>", methods=["GET"])
-@aserto.authorize
+@aserto
 def api_user(id: str) -> Response:
     # Raises an AuthorizationError if the `GET.api.users.__id`
-    # policy returns a decision of "allowed = false" 
+    # policy returns a decision of "allowed = false"
     ...
 ```
 
@@ -104,7 +104,7 @@ def id_mapper() -> str:
 
 @app.route("/resource/<asset>", methods=["GET"])
 @requires_auth
-@aserto.check(objType="resource", objIdMapper=id_mapper, relationName="can_read").authorize
+@aserto.check(objType="resource", objIdMapper=id_mapper, relationName="can_read")
 def get_resource(asset: str):
     return {"message": "Hello from GET /resource/" + asset}
 
@@ -117,7 +117,7 @@ The `check` function accepts options that configure the object, subject, and rel
 
 ```py
     def check(
-        self, 
+        self,
         objId: Optional[str] = "",
         objType: Optional[str] = "",
         objIdMapper: Optional[StringMapper] = None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aiohttp"
-version = "3.9.1"
+version = "3.9.3"
 description = "Async http client/server framework (asyncio)"
 category = "main"
 optional = false
@@ -30,7 +30,7 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "aserto"
-version = "0.30.1"
+version = "0.30.3"
 description = "Aserto API client"
 category = "main"
 optional = false
@@ -57,7 +57,7 @@ protobuf = ">=4.21.0,<5.0.0"
 
 [[package]]
 name = "aserto-directory"
-version = "0.30.0"
+version = "0.30.1"
 description = "gRPC client for Aserto Directory service instances"
 category = "main"
 optional = false
@@ -69,20 +69,6 @@ protobuf = ">=4.21.0,<5.0.0"
 protovalidate = {version = ">=0.3.0,<0.4.0", markers = "python_version >= \"3.11\""}
 
 [[package]]
-name = "asgiref"
-version = "3.7.2"
-description = "ASGI specs, helper code, and adapters"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
-
-[package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
-
-[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -92,7 +78,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "attrs"
-version = "23.1.0"
+version = "23.2.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
@@ -103,11 +89,12 @@ cov = ["attrs", "coverage[toml] (>=5.3)"]
 dev = ["attrs", "pre-commit"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
 tests = ["attrs", "zope-interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest-mypy-plugins", "pytest-xdist", "pytest (>=4.3.0)"]
+tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
+tests-no-zope = ["attrs", "cloudpickle", "hypothesis", "pympler", "pytest-xdist", "pytest (>=4.3.0)"]
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -118,7 +105,7 @@ dev = ["pytest (>=6.0)", "pytest-cov", "freezegun (>=1.0,<2.0)"]
 
 [[package]]
 name = "black"
-version = "23.11.0"
+version = "23.12.1"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -135,7 +122,7 @@ typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
+d = ["aiohttp (>=3.7.4,!=3.9.0)", "aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
@@ -212,14 +199,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "flask"
-version = "3.0.0"
+version = "3.0.1"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 
 [package.dependencies]
-asgiref = {version = ">=3.2", optional = true, markers = "extra == \"async\""}
 blinker = ">=1.6.2"
 click = ">=8.1.3"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
@@ -244,7 +230,7 @@ Flask = ">=0.9"
 
 [[package]]
 name = "frozenlist"
-version = "1.4.0"
+version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
 category = "main"
 optional = false
@@ -252,14 +238,14 @@ python-versions = ">=3.8"
 
 [[package]]
 name = "grpcio"
-version = "1.59.3"
+version = "1.60.0"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.59.3)"]
+protobuf = ["grpcio-tools (>=1.60.0)"]
 
 [[package]]
 name = "idna"
@@ -271,7 +257,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "6.8.0"
+version = "7.0.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -281,7 +267,7 @@ python-versions = ">=3.8"
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "sphinx-lint", "jaraco.tidelift (>=1.4)"]
+docs = ["sphinx (>=3.5)", "sphinx (<7.2.5)", "jaraco.packaging (>=9.3)", "rst.linker (>=1.9)", "furo", "sphinx-lint", "jaraco.tidelift (>=1.4)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ruff", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
@@ -295,17 +281,14 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "isort"
-version = "5.12.0"
+version = "5.13.2"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
 python-versions = ">=3.8.0"
 
 [package.extras]
-colors = ["colorama (>=0.4.3)"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
+colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "itsdangerous"
@@ -317,7 +300,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 category = "main"
 optional = false
@@ -352,7 +335,7 @@ regex = ["regex"]
 
 [[package]]
 name = "markupsafe"
-version = "2.1.3"
+version = "2.1.4"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
@@ -392,19 +375,19 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "pathspec"
-version = "0.11.2"
+version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.24)", "sphinx (>=7.1.1)"]
@@ -412,7 +395,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest-cov (>=4.1)", "pytes
 
 [[package]]
 name = "pluggy"
-version = "1.3.0"
+version = "1.4.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
@@ -424,7 +407,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "4.25.1"
+version = "4.25.2"
 description = ""
 category = "main"
 optional = false
@@ -432,11 +415,11 @@ python-versions = ">=3.8"
 
 [[package]]
 name = "protovalidate"
-version = "0.3.0"
+version = "0.3.1"
 description = "Protocol Buffer Validation for Python"
 category = "main"
 optional = false
-python-versions = ">=3.11"
+python-versions = ">=3.8"
 
 [package.dependencies]
 cel-python = "*"
@@ -444,7 +427,7 @@ protobuf = "*"
 
 [[package]]
 name = "pyright"
-version = "1.1.337"
+version = "1.1.349"
 description = "Command line wrapper for pyright"
 category = "dev"
 optional = false
@@ -459,7 +442,7 @@ dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -531,15 +514,15 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 
 [[package]]
 name = "urllib3"
-version = "2.1.0"
+version = "2.2.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -547,6 +530,7 @@ python-versions = ">=3.8"
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -566,7 +550,7 @@ watchdog = ["watchdog (>=2.3)"]
 
 [[package]]
 name = "yarl"
-version = "1.9.3"
+version = "1.9.4"
 description = "Yet another URL library"
 category = "main"
 optional = false
@@ -591,7 +575,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-ena
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c14d278390ba11bb3cfba8cb91919fe82465ad9ab0f7d8440978c2d845b6f491"
+content-hash = "d55472e61e667529bc1ce00b64e0e399fd057c160025bc2cdcc698b5572ce6c7"
 
 [metadata.files]
 aiohttp = []
@@ -599,7 +583,6 @@ aiosignal = []
 aserto = []
 aserto-authorizer = []
 aserto-directory = []
-asgiref = []
 async-timeout = []
 attrs = []
 babel = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask-aserto"
-version = "0.30.5-dirty"
+version = "0.30.5"
 description = "Aserto integration for Flask"
 readme = "README.md"
 authors = ["Aserto, Inc. <pypi@aserto.com>"]
@@ -29,7 +29,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-version = "0.30.5-dirty"
 Flask-Cors = ">=3.0.0,<5.0.0"
 grpcio = "^1.49.0"
 protobuf = "^4.21.0"

--- a/src/flask_aserto/aio/check.py
+++ b/src/flask_aserto/aio/check.py
@@ -1,27 +1,30 @@
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Optional, Union, cast, TYPE_CHECKING
-if TYPE_CHECKING:
-    from .middleware import AsertoMiddleware
+from typing import Any, Callable, Optional, TYPE_CHECKING, Union, cast, overload
 
 from aserto.client import ResourceContext
 from flask.wrappers import Response
 
 from ._defaults import (
-    IdentityMapper,
-    StringMapper,
-    ResourceMapper,
-    ObjectMapper,
-    Obj,
     AuthorizationError,
-    Handler
+    Handler,
+    IdentityMapper,
+    Obj,
+    ObjectMapper,
+    ResourceMapper,
+    StringMapper,
 )
+
+if TYPE_CHECKING:
+    from .middleware import AsertoMiddleware
+
 
 @dataclass(frozen=True)
 class CheckOptions:
     """
     Check options class used to create a new instance of Check Middleware
     """
+
     objId: Optional[str] = ""
     objType: Optional[str] = ""
     objIdMapper: Optional[StringMapper] = None
@@ -35,53 +38,32 @@ class CheckOptions:
     policyPathMapper: Optional[StringMapper] = None
 
 
-
-def build_resource_context_mapper(
-       opts: CheckOptions
-) -> ResourceMapper:
-
+def build_resource_context_mapper(opts: CheckOptions) -> ResourceMapper:
     async def resource() -> ResourceContext:
-        objid = (
-            opts.objId
-            if opts.objId is not None
-            else ""
-        )
-        objtype = (
-            opts.objType
-            if opts.objType is not None
-            else ""
-        )
-        
+        objid = opts.objId if opts.objId is not None else ""
+        objtype = opts.objType if opts.objType is not None else ""
+
         obj = (
-            await opts.objMapper()
-            if opts.objMapper is not None
-            else Obj(id=objid, objType=objtype)
+            await opts.objMapper() if opts.objMapper is not None else Obj(id=objid, objType=objtype)
         )
-         
-        obj.id = (
-            await opts.objIdMapper()
-            if opts.objIdMapper is not None
-            else obj.id
-        )
+
+        obj.id = await opts.objIdMapper() if opts.objIdMapper is not None else obj.id
 
         relation = (
-            await opts.relationMapper()
-            if opts.relationMapper is not None
-            else opts.relationName
+            await opts.relationMapper() if opts.relationMapper is not None else opts.relationName
         )
 
-        subjType = (
-            opts.subjType
-            if opts.subjType != ""
-            else "user"
-        )
+        subjType = opts.subjType if opts.subjType != "" else "user"
 
-        return {"relation":     relation,
-		"object_type":  obj.objType,
-		"object_id":    obj.id,
-		"subject_type": subjType}
-    
+        return {
+            "relation": relation,
+            "object_type": obj.objType,
+            "object_id": obj.id,
+            "subject_type": subjType,
+        }
+
     return resource
+
 
 class CheckMiddleware:
     def __init__(
@@ -91,7 +73,7 @@ class CheckMiddleware:
         aserto_middleware: "AsertoMiddleware",
     ):
         self._aserto_middleware = aserto_middleware
-        
+
         self._identity_provider = (
             options.subjMapper
             if options.subjMapper is not None
@@ -107,7 +89,7 @@ class CheckMiddleware:
             if not kwargs
             else CheckMiddleware(
                 aserto_middleware=self._aserto_middleware,
-                options = CheckOptions(
+                options=CheckOptions(
                     relationName=kwargs.get("relation_name", self._options.relationName),
                     relationMapper=kwargs.get("relation_mapper", self._options.relationMapper),
                     policyPath=kwargs.get("policy_path", self._options.policyPath),
@@ -122,7 +104,7 @@ class CheckMiddleware:
                 ),
             )
         )
-    
+
     def _build_policy_path_mapper(self) -> StringMapper:
         async def mapper() -> str:
             policy_path = ""
@@ -134,8 +116,29 @@ class CheckMiddleware:
                 if policy_root:
                     policy_path = f"{policy_root}.{policy_path}"
             return policy_path
-        
+
         return mapper
+
+    @overload
+    async def authorize(self, handler: Handler) -> Handler:
+        ...
+
+    @overload
+    async def authorize(
+        self,
+        objId: Optional[str] = "",
+        objType: Optional[str] = "",
+        objIdMapper: Optional[StringMapper] = None,
+        objMapper: Optional[ObjectMapper] = None,
+        relationName: Optional[str] = "",
+        relationMapper: Optional[StringMapper] = None,
+        subjType: Optional[str] = "",
+        subjMapper: Optional[IdentityMapper] = None,
+        policyPath: Optional[str] = "",
+        policyRoot: Optional[str] = "",
+        policyPathMapper: Optional[StringMapper] = None,
+    ) -> Callable[[Handler], Handler]:
+        ...
 
     async def authorize(
         self,
@@ -164,16 +167,24 @@ class CheckMiddleware:
 
         return self._with_overrides(**kwargs)._authorize
 
+    async def __call__(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Union[Handler, Callable[[Handler], Handler]]:
+        return await self.authorize(*args, **kwargs)
+
     def _authorize(self, handler: Handler) -> Handler:
         if self._aserto_middleware._policy_instance_name == None:
             raise TypeError(f"{self._aserto_middleware._policy_instance_name}() should not be None")
-        
+
         if self._aserto_middleware._policy_instance_label == None:
-            self._aserto_middleware._policy_instance_label = self._aserto_middleware._policy_instance_name
+            self._aserto_middleware._policy_instance_label = (
+                self._aserto_middleware._policy_instance_name
+            )
 
         @wraps(handler)
         async def decorated(*args: Any, **kwargs: Any) -> Response:
-
             policy_mapper = self._build_policy_path_mapper()
             resource_context = await self._resource_context_provider()
             decision = await self._aserto_middleware.is_allowed(
@@ -182,14 +193,16 @@ class CheckMiddleware:
                 identity_provider=self._identity_provider,
                 policy_instance_name=self._aserto_middleware._policy_instance_name or "",
                 policy_instance_label=self._aserto_middleware._policy_instance_label or "",
-                policy_path_root=self._options.policyRoot or self._aserto_middleware._policy_path_root,
+                policy_path_root=self._options.policyRoot
+                or self._aserto_middleware._policy_path_root,
                 policy_path_resolver=policy_mapper,
                 resource_context_provider=resource_context,
             )
 
             if not decision:
-                raise AuthorizationError(policy_instance_name=self._aserto_middleware._policy_instance_name, policy_path=policy_mapper()) # type: ignore[arg-type]
+                raise AuthorizationError(policy_instance_name=self._aserto_middleware._policy_instance_name, policy_path=policy_mapper())  # type: ignore[arg-type]
 
             return await handler(*args, **kwargs)
 
         return cast(Handler, decorated)
+


### PR DESCRIPTION
This PR adds support for Python3.8 by adding a `__call__` method to the middleware, which allows them to be used without the `.authorize` suffix.

Instead of 
```py
@app.route("/api/users/<id>", methods=["GET"])
@aserto.authorize
def api_user(id: str) -> Response:
    ...
```

We can write
```py
@app.route("/api/users/<id>", methods=["GET"])
@aserto
def api_user(id: str) -> Response:
    ...
```

And the same is true for the check middleware.